### PR TITLE
add request function to exported singleton

### DIFF
--- a/lib/axios.js
+++ b/lib/axios.js
@@ -78,6 +78,7 @@ Axios.prototype.request = function request(config) {
 
 var defaultInstance = new Axios(defaults);
 var axios = module.exports = bind(Axios.prototype.request, defaultInstance);
+axios.request = bind(Axios.prototype.request, defaultInstance);
 
 // Expose properties from defaultInstance
 axios.defaults = defaultInstance.defaults;


### PR DESCRIPTION
The request function is currently not available on the default instance of axios. This would be very valuable to have so that it can be stubbed with tools like sinon. There are tools out there for completely mocking out the module loading system, but I think that it would be preferable to have a consistent api and allow for easy unit testing.